### PR TITLE
IMUセンサーの姿勢データ取得実装

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,16 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Xen",
+      "request": "launch",
+      "type": "dart"
+    },
+    {
+      "name": "Xen (IMU Debug)",
+      "request": "launch",
+      "type": "dart",
+      "toolArgs": ["--dart-define=IMU_DEBUG=true"]
+    }
+  ]
+}

--- a/android/app/src/main/kotlin/com/example/xen2/ImuPlugin.kt
+++ b/android/app/src/main/kotlin/com/example/xen2/ImuPlugin.kt
@@ -1,0 +1,137 @@
+package com.example.xen2
+
+import android.content.Context
+import android.hardware.Sensor
+import android.hardware.SensorEvent
+import android.hardware.SensorEventListener
+import android.hardware.SensorManager
+import android.os.Handler
+import android.os.Looper
+import io.flutter.embedding.engine.plugins.FlutterPlugin
+import io.flutter.plugin.common.EventChannel
+
+class ImuPlugin : FlutterPlugin {
+    private lateinit var sensorManager: SensorManager
+    private val channels = mutableListOf<EventChannel>()
+
+    override fun onAttachedToEngine(binding: FlutterPlugin.FlutterPluginBinding) {
+        sensorManager = binding.applicationContext
+            .getSystemService(Context.SENSOR_SERVICE) as SensorManager
+
+        val messenger = binding.binaryMessenger
+
+        channels += EventChannel(messenger, "imu_fusion/accelerometer").also {
+            it.setStreamHandler(RawSensorHandler(sensorManager, Sensor.TYPE_ACCELEROMETER))
+        }
+        channels += EventChannel(messenger, "imu_fusion/gyroscope").also {
+            it.setStreamHandler(RawSensorHandler(sensorManager, Sensor.TYPE_GYROSCOPE))
+        }
+        channels += EventChannel(messenger, "imu_fusion/magnetometer").also {
+            it.setStreamHandler(RawSensorHandler(sensorManager, Sensor.TYPE_MAGNETIC_FIELD))
+        }
+        // OS フュージョン済み姿勢データ（内部でカルマンフィルタ等を使用）
+        channels += EventChannel(messenger, "imu_fusion/attitude").also {
+            it.setStreamHandler(RotationVectorHandler(sensorManager))
+        }
+    }
+
+    override fun onDetachedFromEngine(binding: FlutterPlugin.FlutterPluginBinding) {
+        channels.forEach { it.setStreamHandler(null) }
+        channels.clear()
+    }
+}
+
+private class RawSensorHandler(
+    private val sensorManager: SensorManager,
+    private val sensorType: Int,
+) : EventChannel.StreamHandler {
+
+    private var listener: SensorEventListener? = null
+    private val mainHandler = Handler(Looper.getMainLooper())
+
+    override fun onListen(arguments: Any?, events: EventChannel.EventSink) {
+        val sensor = sensorManager.getDefaultSensor(sensorType)
+        if (sensor == null) {
+            events.error("UNAVAILABLE", "Sensor type $sensorType not available on this device", null)
+            return
+        }
+
+        listener = object : SensorEventListener {
+            override fun onSensorChanged(event: SensorEvent) {
+                val payload = mapOf(
+                    "x" to event.values[0].toDouble(),
+                    "y" to event.values[1].toDouble(),
+                    "z" to event.values[2].toDouble(),
+                    "timestamp" to System.currentTimeMillis(),
+                )
+                mainHandler.post { events.success(payload) }
+            }
+
+            override fun onAccuracyChanged(sensor: Sensor, accuracy: Int) {}
+        }
+
+        sensorManager.registerListener(
+            listener,
+            sensor,
+            SensorManager.SENSOR_DELAY_GAME,
+        )
+    }
+
+    override fun onCancel(arguments: Any?) {
+        sensorManager.unregisterListener(listener)
+        listener = null
+    }
+}
+
+private class RotationVectorHandler(
+    private val sensorManager: SensorManager,
+) : EventChannel.StreamHandler {
+
+    private var listener: SensorEventListener? = null
+    private val mainHandler = Handler(Looper.getMainLooper())
+
+    override fun onListen(arguments: Any?, events: EventChannel.EventSink) {
+        val sensor = sensorManager.getDefaultSensor(Sensor.TYPE_ROTATION_VECTOR)
+        if (sensor == null) {
+            events.error("UNAVAILABLE", "Rotation vector sensor not available on this device", null)
+            return
+        }
+
+        listener = object : SensorEventListener {
+            override fun onSensorChanged(event: SensorEvent) {
+                val q = FloatArray(4)
+                SensorManager.getQuaternionFromVector(q, event.values)
+
+                val rotMatrix = FloatArray(9)
+                SensorManager.getRotationMatrixFromVector(rotMatrix, event.values)
+                val orientation = FloatArray(3) // [azimuth, pitch, roll]
+                SensorManager.getOrientation(rotMatrix, orientation)
+
+                val payload = mapOf(
+                    "qw" to q[0].toDouble(),
+                    "qx" to q[1].toDouble(),
+                    "qy" to q[2].toDouble(),
+                    "qz" to q[3].toDouble(),
+                    "yaw"   to orientation[0].toDouble(),
+                    "pitch" to orientation[1].toDouble(),
+                    "roll"  to orientation[2].toDouble(),
+                    "timestamp" to System.currentTimeMillis(),
+                )
+                mainHandler.post { events.success(payload) }
+            }
+
+            override fun onAccuracyChanged(sensor: Sensor, accuracy: Int) {}
+        }
+
+        sensorManager.registerListener(
+            listener,
+            sensor,
+            SensorManager.SENSOR_DELAY_GAME,
+        )
+    }
+
+    override fun onCancel(arguments: Any?) {
+        sensorManager.unregisterListener(listener)
+        listener = null
+    }
+}

--- a/android/app/src/main/kotlin/com/example/xen2/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/example/xen2/MainActivity.kt
@@ -1,5 +1,11 @@
 package com.example.xen2
 
 import io.flutter.embedding.android.FlutterActivity
+import io.flutter.embedding.engine.FlutterEngine
 
-class MainActivity : FlutterActivity()
+class MainActivity : FlutterActivity() {
+    override fun configureFlutterEngine(flutterEngine: FlutterEngine) {
+        super.configureFlutterEngine(flutterEngine)
+        flutterEngine.plugins.add(ImuPlugin())
+    }
+}

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */; };
 		74858FAF1ED2DC5600515810 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74858FAE1ED2DC5600515810 /* AppDelegate.swift */; };
 		7884E8682EC3CC0700C636F2 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7884E8672EC3CC0400C636F2 /* SceneDelegate.swift */; };
+		AABB00021CF9000F007C117D /* ImuPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABB00011CF9000F007C117D /* ImuPlugin.swift */; };
 		97C146FC1CF9000F007C117D /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FA1CF9000F007C117D /* Main.storyboard */; };
 		97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FD1CF9000F007C117D /* Assets.xcassets */; };
 		97C147011CF9000F007C117D /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */; };
@@ -55,6 +56,7 @@
 		74858FAD1ED2DC5600515810 /* Runner-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Runner-Bridging-Header.h"; sourceTree = "<group>"; };
 		74858FAE1ED2DC5600515810 /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		7884E8672EC3CC0400C636F2 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
+		AABB00011CF9000F007C117D /* ImuPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImuPlugin.swift; sourceTree = "<group>"; };
 		7AFA3C8E1D35360C0083082E /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Release.xcconfig; path = Flutter/Release.xcconfig; sourceTree = "<group>"; };
 		9740EEB21CF90195004384FC /* Debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Debug.xcconfig; path = Flutter/Debug.xcconfig; sourceTree = "<group>"; };
 		9740EEB31CF90195004384FC /* Generated.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Generated.xcconfig; path = Flutter/Generated.xcconfig; sourceTree = "<group>"; };
@@ -154,6 +156,7 @@
 				1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */,
 				74858FAE1ED2DC5600515810 /* AppDelegate.swift */,
 				7884E8672EC3CC0400C636F2 /* SceneDelegate.swift */,
+				AABB00011CF9000F007C117D /* ImuPlugin.swift */,
 				74858FAD1ED2DC5600515810 /* Runner-Bridging-Header.h */,
 			);
 			path = Runner;
@@ -383,6 +386,7 @@
 				74858FAF1ED2DC5600515810 /* AppDelegate.swift in Sources */,
 				1498D2341E8E89220040F4C2 /* GeneratedPluginRegistrant.m in Sources */,
 				7884E8682EC3CC0700C636F2 /* SceneDelegate.swift in Sources */,
+				AABB00021CF9000F007C117D /* ImuPlugin.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -3,6 +3,8 @@ import UIKit
 
 @main
 @objc class AppDelegate: FlutterAppDelegate, FlutterImplicitEngineDelegate {
+  private var imuPlugin: ImuPlugin?
+
   override func application(
     _ application: UIApplication,
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
@@ -12,5 +14,9 @@ import UIKit
 
   func didInitializeImplicitFlutterEngine(_ engineBridge: FlutterImplicitEngineBridge) {
     GeneratedPluginRegistrant.register(with: engineBridge.pluginRegistry)
+
+    if let registrar = engineBridge.pluginRegistry.registrar(forPlugin: "ImuPlugin") {
+      imuPlugin = ImuPlugin.register(binaryMessenger: registrar.messenger())
+    }
   }
 }

--- a/ios/Runner/ImuPlugin.swift
+++ b/ios/Runner/ImuPlugin.swift
@@ -1,0 +1,230 @@
+import Flutter
+import CoreMotion
+
+// MARK: - ImuPlugin
+
+/// CoreMotion を EventChannel 経由で Flutter に公開するプラグイン。
+/// CMMotionManager のインスタンスは Apple の推奨に従い 1 つのみ生成する。
+final class ImuPlugin: NSObject {
+    private let motionManager = CMMotionManager()
+    /// センサーコールバックを受け取るキュー（メインスレッドを占有しない）
+    private let queue: OperationQueue = {
+        let q = OperationQueue()
+        q.name = "imu_fusion.motion"
+        q.maxConcurrentOperationCount = 1
+        return q
+    }()
+
+    private static let updateInterval: TimeInterval = 1.0 / 100.0 // 100 Hz
+
+    static func register(binaryMessenger: FlutterBinaryMessenger) -> ImuPlugin {
+        let plugin = ImuPlugin()
+        plugin.setupChannels(binaryMessenger: binaryMessenger)
+        return plugin
+    }
+
+    private func setupChannels(binaryMessenger: FlutterBinaryMessenger) {
+        let interval = ImuPlugin.updateInterval
+
+        FlutterEventChannel(name: "imu_fusion/accelerometer", binaryMessenger: binaryMessenger)
+            .setStreamHandler(AccelerometerHandler(manager: motionManager, queue: queue, interval: interval))
+
+        FlutterEventChannel(name: "imu_fusion/gyroscope", binaryMessenger: binaryMessenger)
+            .setStreamHandler(GyroscopeHandler(manager: motionManager, queue: queue, interval: interval))
+
+        FlutterEventChannel(name: "imu_fusion/magnetometer", binaryMessenger: binaryMessenger)
+            .setStreamHandler(MagnetometerHandler(manager: motionManager, queue: queue, interval: interval))
+
+        // DeviceMotion は OS 内部のカルマンフィルタ済み姿勢データを提供する
+        FlutterEventChannel(name: "imu_fusion/attitude", binaryMessenger: binaryMessenger)
+            .setStreamHandler(AttitudeHandler(manager: motionManager, queue: queue, interval: interval))
+    }
+}
+
+// MARK: - Helpers
+
+private func currentMs() -> Int {
+    Int(Date().timeIntervalSince1970 * 1000)
+}
+
+/// EventSink への書き込みはメインスレッドで行う
+private func sendToSink(_ sink: @escaping FlutterEventSink, _ value: Any) {
+    DispatchQueue.main.async { sink(value) }
+}
+
+// MARK: - AccelerometerHandler
+
+private final class AccelerometerHandler: NSObject, FlutterStreamHandler {
+    private let manager: CMMotionManager
+    private let queue: OperationQueue
+    private let interval: TimeInterval
+
+    init(manager: CMMotionManager, queue: OperationQueue, interval: TimeInterval) {
+        self.manager = manager
+        self.queue = queue
+        self.interval = interval
+    }
+
+    func onListen(withArguments arguments: Any?, eventSink events: @escaping FlutterEventSink) -> FlutterError? {
+        guard manager.isAccelerometerAvailable else {
+            return FlutterError(code: "UNAVAILABLE", message: "Accelerometer not available", details: nil)
+        }
+        manager.accelerometerUpdateInterval = interval
+        manager.startAccelerometerUpdates(to: queue) { [weak self] data, error in
+            guard self != nil else { return }
+            if let error = error {
+                sendToSink(events, FlutterError(code: "ERROR", message: error.localizedDescription, details: nil))
+                return
+            }
+            guard let data = data else { return }
+            // 単位: g → m/s² 変換 (1g = 9.81 m/s²)
+            let g = 9.81
+            sendToSink(events, [
+                "x": data.acceleration.x * g,
+                "y": data.acceleration.y * g,
+                "z": data.acceleration.z * g,
+                "timestamp": currentMs(),
+            ])
+        }
+        return nil
+    }
+
+    func onCancel(withArguments arguments: Any?) -> FlutterError? {
+        manager.stopAccelerometerUpdates()
+        return nil
+    }
+}
+
+// MARK: - GyroscopeHandler
+
+private final class GyroscopeHandler: NSObject, FlutterStreamHandler {
+    private let manager: CMMotionManager
+    private let queue: OperationQueue
+    private let interval: TimeInterval
+
+    init(manager: CMMotionManager, queue: OperationQueue, interval: TimeInterval) {
+        self.manager = manager
+        self.queue = queue
+        self.interval = interval
+    }
+
+    func onListen(withArguments arguments: Any?, eventSink events: @escaping FlutterEventSink) -> FlutterError? {
+        guard manager.isGyroAvailable else {
+            return FlutterError(code: "UNAVAILABLE", message: "Gyroscope not available", details: nil)
+        }
+        manager.gyroUpdateInterval = interval
+        manager.startGyroUpdates(to: queue) { [weak self] data, error in
+            guard self != nil else { return }
+            if let error = error {
+                sendToSink(events, FlutterError(code: "ERROR", message: error.localizedDescription, details: nil))
+                return
+            }
+            guard let data = data else { return }
+            sendToSink(events, [
+                "x": data.rotationRate.x,
+                "y": data.rotationRate.y,
+                "z": data.rotationRate.z,
+                "timestamp": currentMs(),
+            ])
+        }
+        return nil
+    }
+
+    func onCancel(withArguments arguments: Any?) -> FlutterError? {
+        manager.stopGyroUpdates()
+        return nil
+    }
+}
+
+// MARK: - MagnetometerHandler
+
+private final class MagnetometerHandler: NSObject, FlutterStreamHandler {
+    private let manager: CMMotionManager
+    private let queue: OperationQueue
+    private let interval: TimeInterval
+
+    init(manager: CMMotionManager, queue: OperationQueue, interval: TimeInterval) {
+        self.manager = manager
+        self.queue = queue
+        self.interval = interval
+    }
+
+    func onListen(withArguments arguments: Any?, eventSink events: @escaping FlutterEventSink) -> FlutterError? {
+        guard manager.isMagnetometerAvailable else {
+            return FlutterError(code: "UNAVAILABLE", message: "Magnetometer not available", details: nil)
+        }
+        manager.magnetometerUpdateInterval = interval
+        manager.startMagnetometerUpdates(to: queue) { [weak self] data, error in
+            guard self != nil else { return }
+            if let error = error {
+                sendToSink(events, FlutterError(code: "ERROR", message: error.localizedDescription, details: nil))
+                return
+            }
+            guard let data = data else { return }
+            sendToSink(events, [
+                "x": data.magneticField.x,
+                "y": data.magneticField.y,
+                "z": data.magneticField.z,
+                "timestamp": currentMs(),
+            ])
+        }
+        return nil
+    }
+
+    func onCancel(withArguments arguments: Any?) -> FlutterError? {
+        manager.stopMagnetometerUpdates()
+        return nil
+    }
+}
+
+// MARK: - AttitudeHandler
+
+/// OSのカルマンフィルタ済み姿勢データを提供する（CMDeviceMotion）。
+/// 参照フレーム: xArbitraryZVertical（磁北不要、ジャイロ+加速度で動作）
+private final class AttitudeHandler: NSObject, FlutterStreamHandler {
+    private let manager: CMMotionManager
+    private let queue: OperationQueue
+    private let interval: TimeInterval
+
+    init(manager: CMMotionManager, queue: OperationQueue, interval: TimeInterval) {
+        self.manager = manager
+        self.queue = queue
+        self.interval = interval
+    }
+
+    func onListen(withArguments arguments: Any?, eventSink events: @escaping FlutterEventSink) -> FlutterError? {
+        guard manager.isDeviceMotionAvailable else {
+            return FlutterError(code: "UNAVAILABLE", message: "DeviceMotion not available", details: nil)
+        }
+        manager.deviceMotionUpdateInterval = interval
+        manager.startDeviceMotionUpdates(
+            using: .xArbitraryZVertical,
+            to: queue
+        ) { [weak self] motion, error in
+            guard self != nil else { return }
+            if let error = error {
+                sendToSink(events, FlutterError(code: "ERROR", message: error.localizedDescription, details: nil))
+                return
+            }
+            guard let motion = motion else { return }
+            let q = motion.attitude.quaternion
+            let att = motion.attitude
+            sendToSink(events, [
+                "qw": q.w,
+                "qx": q.x,
+                "qy": q.y,
+                "qz": q.z,
+                "roll": att.roll,
+                "pitch": att.pitch,
+                "yaw": att.yaw,
+                "timestamp": currentMs(),
+            ])
+        }
+        return nil
+    }
+
+    func onCancel(withArguments arguments: Any?) -> FlutterError? {
+        manager.stopDeviceMotionUpdates()
+        return nil
+    }
+}

--- a/lib/features/imu/imu_service.dart
+++ b/lib/features/imu/imu_service.dart
@@ -1,0 +1,109 @@
+import 'dart:async';
+import 'package:flutter/services.dart';
+
+class ImuData {
+  final double x;
+  final double y;
+  final double z;
+  final int timestampMs;
+
+  const ImuData({
+    required this.x,
+    required this.y,
+    required this.z,
+    required this.timestampMs,
+  });
+
+  factory ImuData.fromMap(Map<dynamic, dynamic> map) {
+    return ImuData(
+      x: (map['x'] as num).toDouble(),
+      y: (map['y'] as num).toDouble(),
+      z: (map['z'] as num).toDouble(),
+      timestampMs: (map['timestamp'] as num).toInt(),
+    );
+  }
+
+  @override
+  String toString() =>
+      'ImuData(x: ${x.toStringAsFixed(4)}, y: ${y.toStringAsFixed(4)}, z: ${z.toStringAsFixed(4)})';
+}
+
+/// OSが内部センサーフュージョン（カルマンフィルタ等）で算出した姿勢データ。
+/// iOS: CMDeviceMotion.attitude / Android: TYPE_ROTATION_VECTOR
+class AttitudeData {
+  final double qw;
+  final double qx;
+  final double qy;
+  final double qz;
+
+  /// ラジアン単位。
+  /// iOS/Android ともに右手系だが座標軸の定義が異なる点に注意。
+  final double roll;
+  final double pitch;
+  final double yaw;
+
+  final int timestampMs;
+
+  const AttitudeData({
+    required this.qw,
+    required this.qx,
+    required this.qy,
+    required this.qz,
+    required this.roll,
+    required this.pitch,
+    required this.yaw,
+    required this.timestampMs,
+  });
+
+  factory AttitudeData.fromMap(Map<dynamic, dynamic> map) {
+    return AttitudeData(
+      qw: (map['qw'] as num).toDouble(),
+      qx: (map['qx'] as num).toDouble(),
+      qy: (map['qy'] as num).toDouble(),
+      qz: (map['qz'] as num).toDouble(),
+      roll: (map['roll'] as num).toDouble(),
+      pitch: (map['pitch'] as num).toDouble(),
+      yaw: (map['yaw'] as num).toDouble(),
+      timestampMs: (map['timestamp'] as num).toInt(),
+    );
+  }
+}
+
+class ImuService {
+  ImuService._();
+  static final ImuService instance = ImuService._();
+
+  static const _accelChannel = EventChannel('imu_fusion/accelerometer');
+  static const _gyroChannel = EventChannel('imu_fusion/gyroscope');
+  static const _magChannel = EventChannel('imu_fusion/magnetometer');
+  static const _attitudeChannel = EventChannel('imu_fusion/attitude');
+
+  Stream<ImuData>? _accelerometerStream;
+  Stream<ImuData>? _gyroscopeStream;
+  Stream<ImuData>? _magnetometerStream;
+  Stream<AttitudeData>? _attitudeStream;
+
+  /// 加速度 (m/s²)
+  Stream<ImuData> get accelerometerStream =>
+      _accelerometerStream ??= _accelChannel
+          .receiveBroadcastStream()
+          .map((e) => ImuData.fromMap(e as Map));
+
+  /// 角速度 (rad/s)
+  Stream<ImuData> get gyroscopeStream =>
+      _gyroscopeStream ??= _gyroChannel
+          .receiveBroadcastStream()
+          .map((e) => ImuData.fromMap(e as Map));
+
+  /// 磁場強度 (µT)
+  Stream<ImuData> get magnetometerStream =>
+      _magnetometerStream ??= _magChannel
+          .receiveBroadcastStream()
+          .map((e) => ImuData.fromMap(e as Map));
+
+  /// OSフュージョン済み姿勢データ（クォータニオン + オイラー角）
+  Stream<AttitudeData> get attitudeStream =>
+      _attitudeStream ??= _attitudeChannel
+          .receiveBroadcastStream()
+          .map((e) => AttitudeData.fromMap(e as Map));
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,7 +3,10 @@ import 'package:flutter/services.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:xen2/constants/app_colors.dart';
+import 'package:xen2/pages/imu_debug_page.dart';
 import 'package:xen2/pages/top_page.dart';
+
+const _imuDebug = bool.fromEnvironment('IMU_DEBUG');
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -26,7 +29,7 @@ class MyApp extends StatelessWidget {
       theme: ThemeData(
         colorScheme: ColorScheme.fromSeed(seedColor: AppColors.primary),
       ),
-      home: const TopPage(),
+      home: _imuDebug ? const ImuDebugPage() : const TopPage(),
     );
   }
 }

--- a/lib/pages/imu_debug_page.dart
+++ b/lib/pages/imu_debug_page.dart
@@ -1,0 +1,213 @@
+import 'dart:math';
+import 'package:flutter/material.dart';
+import 'package:xen2/features/imu/imu_service.dart';
+
+class ImuDebugPage extends StatelessWidget {
+  const ImuDebugPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final service = ImuService.instance;
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('IMU Debug'),
+        backgroundColor: Theme.of(context).colorScheme.inversePrimary,
+      ),
+      body: SafeArea(
+        child: ListView(
+          padding: const EdgeInsets.all(12),
+          children: [
+            _ImuCard(
+              title: 'Accelerometer',
+              subtitle: 'm/s²',
+              stream: service.accelerometerStream,
+              builder: (data) => _XyzDisplay(x: data.x, y: data.y, z: data.z),
+            ),
+            const SizedBox(height: 12),
+            _ImuCard(
+              title: 'Gyroscope',
+              subtitle: 'rad/s',
+              stream: service.gyroscopeStream,
+              builder: (data) => _XyzDisplay(x: data.x, y: data.y, z: data.z),
+            ),
+            const SizedBox(height: 12),
+            _ImuCard(
+              title: 'Magnetometer',
+              subtitle: 'µT',
+              stream: service.magnetometerStream,
+              builder: (data) => _XyzDisplay(x: data.x, y: data.y, z: data.z),
+            ),
+            const SizedBox(height: 12),
+            _AttitudeCard(stream: service.attitudeStream),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _ImuCard<T> extends StatelessWidget {
+  const _ImuCard({
+    required this.title,
+    required this.subtitle,
+    required this.stream,
+    required this.builder,
+  });
+
+  final String title;
+  final String subtitle;
+  final Stream<T> stream;
+  final Widget Function(T data) builder;
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(title, style: Theme.of(context).textTheme.titleMedium),
+            Text(
+              subtitle,
+              style: Theme.of(
+                context,
+              ).textTheme.bodySmall?.copyWith(color: Colors.grey),
+            ),
+            const SizedBox(height: 12),
+            StreamBuilder<T>(
+              stream: stream,
+              builder: (context, snapshot) {
+                if (snapshot.hasError) {
+                  return Text(
+                    'Error: ${snapshot.error}',
+                    style: const TextStyle(color: Colors.red),
+                  );
+                }
+                if (!snapshot.hasData) {
+                  return const Center(child: CircularProgressIndicator());
+                }
+                return builder(snapshot.data as T);
+              },
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _AttitudeCard extends StatelessWidget {
+  const _AttitudeCard({required this.stream});
+  final Stream<AttitudeData> stream;
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              'Attitude (OS Fused)',
+              style: Theme.of(context).textTheme.titleMedium,
+            ),
+            Text(
+              'iOS: CMDeviceMotion.attitude / Android: TYPE_ROTATION_VECTOR',
+              style: Theme.of(
+                context,
+              ).textTheme.bodySmall?.copyWith(color: Colors.grey),
+            ),
+            const SizedBox(height: 12),
+            StreamBuilder<AttitudeData>(
+              stream: stream,
+              builder: (context, snapshot) {
+                if (snapshot.hasError) {
+                  return Text(
+                    'Error: ${snapshot.error}',
+                    style: const TextStyle(color: Colors.red),
+                  );
+                }
+                if (!snapshot.hasData) {
+                  return const Center(child: CircularProgressIndicator());
+                }
+                final d = snapshot.data!;
+                final toDeg = 180 / pi;
+                return Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      'Euler Angles (deg)',
+                      style: Theme.of(context).textTheme.labelMedium,
+                    ),
+                    const SizedBox(height: 4),
+                    _ValueRow('Roll ', d.roll * toDeg),
+                    _ValueRow('Pitch', d.pitch * toDeg),
+                    _ValueRow('Yaw  ', d.yaw * toDeg),
+                    const Divider(height: 20),
+                    Text(
+                      'Quaternion',
+                      style: Theme.of(context).textTheme.labelMedium,
+                    ),
+                    const SizedBox(height: 4),
+                    _ValueRow('w', d.qw),
+                    _ValueRow('x', d.qx),
+                    _ValueRow('y', d.qy),
+                    _ValueRow('z', d.qz),
+                  ],
+                );
+              },
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _XyzDisplay extends StatelessWidget {
+  const _XyzDisplay({required this.x, required this.y, required this.z});
+  final double x;
+  final double y;
+  final double z;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [_ValueRow('x', x), _ValueRow('y', y), _ValueRow('z', z)],
+    );
+  }
+}
+
+class _ValueRow extends StatelessWidget {
+  const _ValueRow(this.label, this.value);
+  final String label;
+  final double value;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 2),
+      child: Row(
+        children: [
+          SizedBox(
+            width: 44,
+            child: Text(
+              label,
+              style: const TextStyle(
+                fontFamily: 'monospace',
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+          ),
+          Text(
+            value.toStringAsFixed(5),
+            style: const TextStyle(fontFamily: 'monospace'),
+          ),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
close #21 

## 概要

- iOS(CoreMotion) / Android(SensorManager) のネイティブプラグインを実装し、加速度・ジャイロ・磁気・姿勢(OSフュージョン済み)の4つをEventChannel経由で取得
- `ImuService` でストリームをラップし、`ImuDebugPage` でリアルタイム確認できるデバッグ画面を追加
- `--dart-define=IMU_DEBUG=true` を渡すと起動画面が `ImuDebugPage` に切り替わる構成にし、`.vscode/launch.json` に設定を追記
