### PR TITLE
画面の追加と閾値の調整、およびバグ修正

### DIFF
--- a/lib/features/pavlok/pavlok_provider.dart
+++ b/lib/features/pavlok/pavlok_provider.dart
@@ -26,7 +26,7 @@ Future<void> pavlok(Ref ref) async {
           'Authorization': 'Bearer $apiKey',
         },
         body: jsonEncode({
-          'stimulus': {'stimulusType': 'zap', 'stimulusValue': 25},
+          'stimulus': {'stimulusType': 'zap', 'stimulusValue': 40},
         }),
       )
       .timeout(const Duration(seconds: 5));

--- a/lib/features/pavlok/pavlok_provider.g.dart
+++ b/lib/features/pavlok/pavlok_provider.g.dart
@@ -40,4 +40,4 @@ final class PavlokProvider
   }
 }
 
-String _$pavlokHash() => r'74d37bd27aca710a786c95a8e7bf7f7caf5fc085';
+String _$pavlokHash() => r'bb1bfa0553663eed9b6b1b49e8d5ad2f20aa1017';

--- a/lib/features/zazen/zazen_flow_provider.dart
+++ b/lib/features/zazen/zazen_flow_provider.dart
@@ -215,7 +215,7 @@ class ZazenFlow extends _$ZazenFlow {
     _katsuResumeTimer?.cancel();
     _katsuResumeTimer = Timer(const Duration(seconds: 11), () {
       if (state.phase == ZazenFlowPhase.inProgress) {
-        ref.read(zazenKatsuProvider.notifier).start();
+        ref.read(zazenKatsuProvider.notifier).start(armed: true);
       }
     });
     final zazenDuration = Duration(minutes: ref.read(zazenDurationProvider));

--- a/lib/features/zazen/zazen_flow_provider.dart
+++ b/lib/features/zazen/zazen_flow_provider.dart
@@ -12,6 +12,8 @@ part 'zazen_flow_provider.g.dart';
 
 enum ZazenFlowPhase {
   idle,
+  wearablePrompt,
+  earphonePrompt,
   calibrating,
   postureConfirmed,
   koan,
@@ -93,6 +95,17 @@ class ZazenFlow extends _$ZazenFlow {
 
   // ---- Public API ----
 
+  void advanceWearablePrompt() {
+    if (state.phase != ZazenFlowPhase.wearablePrompt) return;
+    state = state.copyWith(phase: ZazenFlowPhase.earphonePrompt);
+  }
+
+  void advanceEarphonePrompt() {
+    if (state.phase != ZazenFlowPhase.earphonePrompt) return;
+    state = state.copyWith(phase: ZazenFlowPhase.calibrating);
+    ref.read(zazenCalibrationProvider.notifier).start();
+  }
+
   void start() {
     _cancelAllTimers();
     _imuSub?.cancel();
@@ -105,8 +118,7 @@ class ZazenFlow extends _$ZazenFlow {
     Future<void>(() {
       ref.read(zazenCalibrationProvider.notifier).reset();
       ref.read(zazenKatsuProvider.notifier).stop();
-      state = const ZazenFlowState(phase: ZazenFlowPhase.calibrating);
-      ref.read(zazenCalibrationProvider.notifier).start();
+      state = const ZazenFlowState(phase: ZazenFlowPhase.wearablePrompt);
     });
   }
 

--- a/lib/features/zazen/zazen_flow_provider.dart
+++ b/lib/features/zazen/zazen_flow_provider.dart
@@ -211,8 +211,13 @@ class ZazenFlow extends _$ZazenFlow {
 
   void _toInProgress() {
     state = state.copyWith(phase: ZazenFlowPhase.inProgress);
-    ref.read(zazenKatsuProvider.notifier).start();
     _startSampling();
+    _katsuResumeTimer?.cancel();
+    _katsuResumeTimer = Timer(const Duration(seconds: 11), () {
+      if (state.phase == ZazenFlowPhase.inProgress) {
+        ref.read(zazenKatsuProvider.notifier).start();
+      }
+    });
     final zazenDuration = Duration(minutes: ref.read(zazenDurationProvider));
     _schedule(zazenDuration - const Duration(seconds: 5), _stopKatsuBeforeEnd);
   }

--- a/lib/features/zazen/zazen_flow_provider.g.dart
+++ b/lib/features/zazen/zazen_flow_provider.g.dart
@@ -41,7 +41,7 @@ final class ZazenFlowProvider
   }
 }
 
-String _$zazenFlowHash() => r'8d332e31e72a2ec61030277bbd072269716f9d1d';
+String _$zazenFlowHash() => r'6e2efacb89eceed7eaae1c31109720aefa3cfd26';
 
 abstract class _$ZazenFlow extends $Notifier<ZazenFlowState> {
   ZazenFlowState build();

--- a/lib/features/zazen/zazen_katsu_provider.g.dart
+++ b/lib/features/zazen/zazen_katsu_provider.g.dart
@@ -41,7 +41,7 @@ final class ZazenKatsuProvider
   }
 }
 
-String _$zazenKatsuHash() => r'4d5cc8a67411acff519098ff68145f9e8a6dd2be';
+String _$zazenKatsuHash() => r'5e2c1f2aaf26ebe286de9a9bf51a3a30c04f28cc';
 
 abstract class _$ZazenKatsu extends $Notifier<KatsuStatus> {
   KatsuStatus build();

--- a/lib/pages/play_page.dart
+++ b/lib/pages/play_page.dart
@@ -243,6 +243,8 @@ class PlayPageState extends ConsumerState<PlayPage>
 
     return switch (flow.phase) {
       ZazenFlowPhase.idle => const SizedBox.shrink(),
+      ZazenFlowPhase.wearablePrompt => const SizedBox.shrink(),
+      ZazenFlowPhase.earphonePrompt => const SizedBox.shrink(),
       ZazenFlowPhase.calibrating => const PostureDetecting(),
       ZazenFlowPhase.postureConfirmed => const PostureConfirmed(),
       ZazenFlowPhase.koan =>
@@ -281,6 +283,36 @@ class PlayPageState extends ConsumerState<PlayPage>
             assetPath: 'assets/skybox.mp4',
             foregroundWidget: _buildForegroundWidget(flowState, katsuStatus),
           ),
+          if (flowState.phase == ZazenFlowPhase.wearablePrompt)
+            Positioned.fill(
+              child: GestureDetector(
+                onTap: _zazenFlowNotifier.advanceWearablePrompt,
+                child: const ColoredBox(
+                  color: Colors.transparent,
+                  child: Center(
+                    child: OutlinedText(
+                      text: 'ウェアラブルデバイスを装着してください。\n装着後、画面をタップしてください。',
+                      fontSize: 20,
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          if (flowState.phase == ZazenFlowPhase.earphonePrompt)
+            Positioned.fill(
+              child: GestureDetector(
+                onTap: _zazenFlowNotifier.advanceEarphonePrompt,
+                child: const ColoredBox(
+                  color: Colors.transparent,
+                  child: Center(
+                    child: OutlinedText(
+                      text: 'イヤホンを装着してください。\n装着後、画面をタップしてください。',
+                      fontSize: 20,
+                    ),
+                  ),
+                ),
+              ),
+            ),
           if (flowState.phase == ZazenFlowPhase.tapWaiting)
             Positioned.fill(
               child: GestureDetector(
@@ -295,7 +327,7 @@ class PlayPageState extends ConsumerState<PlayPage>
                 child: const ColoredBox(
                   color: Colors.transparent,
                   child: Center(
-                    child: OutlinedText(text: 'タップしてください', fontSize: 20),
+                    child: OutlinedText(text: '画面をタップしてください', fontSize: 20),
                   ),
                 ),
               ),


### PR DESCRIPTION
close #66 

- 坐禅開始前に「ウェアラブルデバイスを装着してください」「イヤホンを装着してください」の2画面を追加し、それぞれタップで次に進むようにした
- Pavlok（警策）の刺激値を 25 → 40 に引き上げた
- 鐘の音が鳴っている間（11秒間）は喝の検出を開始しないようにした
- 鐘終了後の喝検出を armed: true で開始するようにし、開始時点ですでに崩れた姿勢だった場合も正しく喝が発動するよう修正した