### PR TITLE
pavlok（電流）以外の対応

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -2,6 +2,8 @@ PODS:
   - audioplayers_darwin (0.0.1):
     - Flutter
     - FlutterMacOS
+  - device_info_plus (0.0.1):
+    - Flutter
   - Flutter (1.0.0)
   - flutter_native_splash (2.4.3):
     - Flutter
@@ -29,6 +31,8 @@ PODS:
     - PlayKit/Core
   - SwiftyJSON (5.0.0)
   - SwiftyXMLParser (5.0.0)
+  - vibration (3.0.0):
+    - Flutter
   - vr_player (0.0.1):
     - Flutter
     - PlayKitProviders
@@ -40,8 +44,10 @@ PODS:
 
 DEPENDENCIES:
   - audioplayers_darwin (from `.symlinks/plugins/audioplayers_darwin/darwin`)
+  - device_info_plus (from `.symlinks/plugins/device_info_plus/ios`)
   - Flutter (from `Flutter`)
   - flutter_native_splash (from `.symlinks/plugins/flutter_native_splash/ios`)
+  - vibration (from `.symlinks/plugins/vibration/ios`)
   - vr_player (from `.symlinks/plugins/vr_player/ios`)
 
 SPEC REPOS:
@@ -59,15 +65,20 @@ SPEC REPOS:
 EXTERNAL SOURCES:
   audioplayers_darwin:
     :path: ".symlinks/plugins/audioplayers_darwin/darwin"
+  device_info_plus:
+    :path: ".symlinks/plugins/device_info_plus/ios"
   Flutter:
     :path: Flutter
   flutter_native_splash:
     :path: ".symlinks/plugins/flutter_native_splash/ios"
+  vibration:
+    :path: ".symlinks/plugins/vibration/ios"
   vr_player:
     :path: ".symlinks/plugins/vr_player/ios"
 
 SPEC CHECKSUMS:
   audioplayers_darwin: 835ced6edd4c9fc8ebb0a7cc9e294a91d99917d5
+  device_info_plus: 21fcca2080fbcd348be798aa36c3e5ed849eefbe
   Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
   flutter_native_splash: c32d145d68aeda5502d5f543ee38c192065986cf
   KalturaNetKit: 2af6c3c2a1abbd8936b5acde45f33f5195125f4a
@@ -78,6 +89,7 @@ SPEC CHECKSUMS:
   PlayKitVR: f8e0d16d011b7092838819d4e649d5d77923b62d
   SwiftyJSON: 36413e04c44ee145039d332b4f4e2d3e8d6c4db7
   SwiftyXMLParser: 5ebb8793192f403fa8cc691045143906122a7a75
+  vibration: ca8104a8875b9c493e15b21b04e456befd0ff6eb
   vr_player: d00629ddccb37d026c16182e3ea2021ffba0a4e4
   XCGLogger: 0434f15e3909cdc450bb63faf638b8792ab782ab
 

--- a/lib/features/katsu_settings/katsu_settings_dialog.dart
+++ b/lib/features/katsu_settings/katsu_settings_dialog.dart
@@ -1,0 +1,92 @@
+import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:xen2/constants/app_colors.dart';
+import 'package:xen2/features/katsu_settings/katsu_settings_provider.dart';
+
+class KatsuSettingsDialog extends ConsumerWidget {
+  const KatsuSettingsDialog({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final settings = ref.watch(katsuSettingsProvider);
+    final notifier = ref.read(katsuSettingsProvider.notifier);
+
+    return AlertDialog(
+      backgroundColor: AppColors.background,
+      title: const Text(
+        '喝の設定',
+        style: TextStyle(
+          color: AppColors.textPrimary,
+          fontWeight: FontWeight.bold,
+        ),
+      ),
+      content: SingleChildScrollView(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            SwitchListTile(
+              title: const Text(
+                'Pavlok',
+                style: TextStyle(color: AppColors.textPrimary),
+              ),
+              value: settings.pavlokEnabled,
+              activeThumbColor: AppColors.primary,
+              onChanged: notifier.setPavlokEnabled,
+              contentPadding: EdgeInsets.zero,
+            ),
+            const SizedBox(height: 8),
+            Text(
+              '刺激値: ${settings.stimulusValue}',
+              style: TextStyle(
+                color: settings.pavlokEnabled
+                    ? AppColors.textPrimary
+                    : AppColors.textPrimary.withValues(alpha: 0.4),
+                fontSize: 14,
+              ),
+            ),
+            Slider(
+              value: settings.stimulusValue.toDouble(),
+              min: 0,
+              max: 100,
+              divisions: 100,
+              activeColor: settings.pavlokEnabled
+                  ? AppColors.primary
+                  : AppColors.primary.withValues(alpha: 0.3),
+              label: settings.stimulusValue.toString(),
+              onChanged: settings.pavlokEnabled
+                  ? (v) => notifier.setStimulusValue(v.round())
+                  : null,
+            ),
+            const SizedBox(height: 8),
+            SwitchListTile(
+              title: Text(
+                'バイブ',
+                style: TextStyle(
+                  color: settings.pavlokEnabled
+                      ? AppColors.textPrimary.withValues(alpha: 0.4)
+                      : AppColors.textPrimary,
+                ),
+              ),
+              value: settings.vibrationEnabled,
+              activeThumbColor: AppColors.primary,
+              onChanged: settings.pavlokEnabled
+                  ? null
+                  : notifier.setVibrationEnabled,
+              contentPadding: EdgeInsets.zero,
+            ),
+          ],
+        ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.pop(context),
+          child: const Text(
+            '閉じる',
+            style: TextStyle(color: AppColors.primary),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/features/katsu_settings/katsu_settings_provider.dart
+++ b/lib/features/katsu_settings/katsu_settings_provider.dart
@@ -1,0 +1,42 @@
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'katsu_settings_provider.g.dart';
+
+class KatsuSettingsState {
+  final bool pavlokEnabled;
+  final int stimulusValue;
+  final bool vibrationEnabled;
+
+  const KatsuSettingsState({
+    this.pavlokEnabled = true,
+    this.stimulusValue = 40,
+    this.vibrationEnabled = true,
+  });
+
+  KatsuSettingsState copyWith({
+    bool? pavlokEnabled,
+    int? stimulusValue,
+    bool? vibrationEnabled,
+  }) {
+    return KatsuSettingsState(
+      pavlokEnabled: pavlokEnabled ?? this.pavlokEnabled,
+      stimulusValue: stimulusValue ?? this.stimulusValue,
+      vibrationEnabled: vibrationEnabled ?? this.vibrationEnabled,
+    );
+  }
+}
+
+@Riverpod(keepAlive: true)
+class KatsuSettings extends _$KatsuSettings {
+  @override
+  KatsuSettingsState build() => const KatsuSettingsState();
+
+  void setPavlokEnabled(bool value) =>
+      state = state.copyWith(pavlokEnabled: value);
+
+  void setStimulusValue(int value) =>
+      state = state.copyWith(stimulusValue: value);
+
+  void setVibrationEnabled(bool value) =>
+      state = state.copyWith(vibrationEnabled: value);
+}

--- a/lib/features/katsu_settings/katsu_settings_provider.g.dart
+++ b/lib/features/katsu_settings/katsu_settings_provider.g.dart
@@ -1,0 +1,62 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'katsu_settings_provider.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
+@ProviderFor(KatsuSettings)
+final katsuSettingsProvider = KatsuSettingsProvider._();
+
+final class KatsuSettingsProvider
+    extends $NotifierProvider<KatsuSettings, KatsuSettingsState> {
+  KatsuSettingsProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'katsuSettingsProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$katsuSettingsHash();
+
+  @$internal
+  @override
+  KatsuSettings create() => KatsuSettings();
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(KatsuSettingsState value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<KatsuSettingsState>(value),
+    );
+  }
+}
+
+String _$katsuSettingsHash() => r'38c1748c465b0ea4d9385b71bded28680003f29e';
+
+abstract class _$KatsuSettings extends $Notifier<KatsuSettingsState> {
+  KatsuSettingsState build();
+  @$mustCallSuper
+  @override
+  void runBuild() {
+    final ref = this.ref as $Ref<KatsuSettingsState, KatsuSettingsState>;
+    final element =
+        ref.element
+            as $ClassProviderElement<
+              AnyNotifier<KatsuSettingsState, KatsuSettingsState>,
+              KatsuSettingsState,
+              Object?,
+              Object?
+            >;
+    element.handleCreate(ref, build);
+  }
+}

--- a/lib/features/pavlok/pavlok_provider.dart
+++ b/lib/features/pavlok/pavlok_provider.dart
@@ -8,7 +8,7 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 part 'pavlok_provider.g.dart';
 
 @riverpod
-Future<void> pavlok(Ref ref) async {
+Future<void> pavlok(Ref ref, int stimulusValue) async {
   const pavlokUrl = 'https://api.pavlok.com/api/v5/stimulus/send';
   final apiKey = dotenv.env['PAVLOK_API_KEY'] ?? '';
 
@@ -26,7 +26,7 @@ Future<void> pavlok(Ref ref) async {
           'Authorization': 'Bearer $apiKey',
         },
         body: jsonEncode({
-          'stimulus': {'stimulusType': 'zap', 'stimulusValue': 40},
+          'stimulus': {'stimulusType': 'zap', 'stimulusValue': stimulusValue},
         }),
       )
       .timeout(const Duration(seconds: 5));

--- a/lib/features/pavlok/pavlok_provider.g.dart
+++ b/lib/features/pavlok/pavlok_provider.g.dart
@@ -10,24 +10,31 @@ part of 'pavlok_provider.dart';
 // ignore_for_file: type=lint, type=warning
 
 @ProviderFor(pavlok)
-final pavlokProvider = PavlokProvider._();
+final pavlokProvider = PavlokFamily._();
 
 final class PavlokProvider
     extends $FunctionalProvider<AsyncValue<void>, void, FutureOr<void>>
     with $FutureModifier<void>, $FutureProvider<void> {
-  PavlokProvider._()
-    : super(
-        from: null,
-        argument: null,
-        retry: null,
-        name: r'pavlokProvider',
-        isAutoDispose: true,
-        dependencies: null,
-        $allTransitiveDependencies: null,
-      );
+  PavlokProvider._({
+    required PavlokFamily super.from,
+    required int super.argument,
+  }) : super(
+         retry: null,
+         name: r'pavlokProvider',
+         isAutoDispose: true,
+         dependencies: null,
+         $allTransitiveDependencies: null,
+       );
 
   @override
   String debugGetCreateSourceHash() => _$pavlokHash();
+
+  @override
+  String toString() {
+    return r'pavlokProvider'
+        ''
+        '($argument)';
+  }
 
   @$internal
   @override
@@ -36,8 +43,37 @@ final class PavlokProvider
 
   @override
   FutureOr<void> create(Ref ref) {
-    return pavlok(ref);
+    final argument = this.argument as int;
+    return pavlok(ref, argument);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return other is PavlokProvider && other.argument == argument;
+  }
+
+  @override
+  int get hashCode {
+    return argument.hashCode;
   }
 }
 
-String _$pavlokHash() => r'bb1bfa0553663eed9b6b1b49e8d5ad2f20aa1017';
+String _$pavlokHash() => r'289b4120d9a746da11c537cc90cc1e5099af8cad';
+
+final class PavlokFamily extends $Family
+    with $FunctionalFamilyOverride<FutureOr<void>, int> {
+  PavlokFamily._()
+    : super(
+        retry: null,
+        name: r'pavlokProvider',
+        dependencies: null,
+        $allTransitiveDependencies: null,
+        isAutoDispose: true,
+      );
+
+  PavlokProvider call(int stimulusValue) =>
+      PavlokProvider._(argument: stimulusValue, from: this);
+
+  @override
+  String toString() => r'pavlokProvider';
+}

--- a/lib/features/zazen/zazen_flow_provider.dart
+++ b/lib/features/zazen/zazen_flow_provider.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:flutter/foundation.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:xen2/features/imu/imu_service.dart';
+import 'package:xen2/features/katsu_settings/katsu_settings_provider.dart';
 import 'package:xen2/features/zazen/koans.dart';
 import 'package:xen2/features/zazen/zazen_calibration_provider.dart';
 import 'package:xen2/features/zazen/zazen_duration_provider.dart';
@@ -118,7 +119,11 @@ class ZazenFlow extends _$ZazenFlow {
     Future<void>(() {
       ref.read(zazenCalibrationProvider.notifier).reset();
       ref.read(zazenKatsuProvider.notifier).stop();
-      state = const ZazenFlowState(phase: ZazenFlowPhase.wearablePrompt);
+      final pavlokEnabled = ref.read(katsuSettingsProvider).pavlokEnabled;
+      final initialPhase = pavlokEnabled
+          ? ZazenFlowPhase.wearablePrompt
+          : ZazenFlowPhase.earphonePrompt;
+      state = ZazenFlowState(phase: initialPhase);
     });
   }
 

--- a/lib/features/zazen/zazen_flow_provider.g.dart
+++ b/lib/features/zazen/zazen_flow_provider.g.dart
@@ -41,7 +41,7 @@ final class ZazenFlowProvider
   }
 }
 
-String _$zazenFlowHash() => r'1ecf9ae8a5d408837010148fe45e4b4f74dffa09';
+String _$zazenFlowHash() => r'cbf6bf90bd10cc78871dd952fe119194d038e6ff';
 
 abstract class _$ZazenFlow extends $Notifier<ZazenFlowState> {
   ZazenFlowState build();

--- a/lib/features/zazen/zazen_flow_provider.g.dart
+++ b/lib/features/zazen/zazen_flow_provider.g.dart
@@ -41,7 +41,7 @@ final class ZazenFlowProvider
   }
 }
 
-String _$zazenFlowHash() => r'6e2efacb89eceed7eaae1c31109720aefa3cfd26';
+String _$zazenFlowHash() => r'1ecf9ae8a5d408837010148fe45e4b4f74dffa09';
 
 abstract class _$ZazenFlow extends $Notifier<ZazenFlowState> {
   ZazenFlowState build();

--- a/lib/features/zazen/zazen_katsu_provider.dart
+++ b/lib/features/zazen/zazen_katsu_provider.dart
@@ -3,7 +3,9 @@ import 'dart:math';
 
 import 'package:flutter/foundation.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'package:vibration/vibration.dart';
 import 'package:xen2/features/imu/imu_service.dart';
+import 'package:xen2/features/katsu_settings/katsu_settings_provider.dart';
 import 'package:xen2/features/pavlok/pavlok_provider.dart';
 
 part 'zazen_katsu_provider.g.dart';
@@ -116,14 +118,22 @@ class ZazenKatsu extends _$ZazenKatsu {
     _warningTimer?.cancel();
     state = KatsuStatus.warning;
     _warningTimer = Timer(const Duration(seconds: 3), () {
-      // 喝: Pavlokへ刺激を送る
-      ref.read(pavlokProvider.future).catchError((e) {
-        debugPrint('Failed to connect to Pavlok: $e');
-      });
+      _doKatsu();
       state = KatsuStatus.cooldown;
       _cooldownTimer = Timer(const Duration(seconds: 5), () {
         state = KatsuStatus.detected;
       });
     });
+  }
+
+  void _doKatsu() {
+    final settings = ref.read(katsuSettingsProvider);
+    if (settings.pavlokEnabled) {
+      ref.read(pavlokProvider(settings.stimulusValue).future).catchError((e) {
+        debugPrint('Failed to connect to Pavlok: $e');
+      });
+    } else if (settings.vibrationEnabled) {
+      Vibration.vibrate(duration: 500);
+    }
   }
 }

--- a/lib/features/zazen/zazen_katsu_provider.g.dart
+++ b/lib/features/zazen/zazen_katsu_provider.g.dart
@@ -41,7 +41,7 @@ final class ZazenKatsuProvider
   }
 }
 
-String _$zazenKatsuHash() => r'5e2c1f2aaf26ebe286de9a9bf51a3a30c04f28cc';
+String _$zazenKatsuHash() => r'4d8897a54365d5670c9d34fa9abea3f2bc98cc58';
 
 abstract class _$ZazenKatsu extends $Notifier<KatsuStatus> {
   KatsuStatus build();

--- a/lib/pages/top_page.dart
+++ b/lib/pages/top_page.dart
@@ -60,7 +60,7 @@ class TopPage extends ConsumerWidget {
             right: 0,
             child: GestureDetector(
               behavior: HitTestBehavior.opaque,
-              onTap: () => showDialog(
+              onLongPress: () => showDialog(
                 context: context,
                 builder: (_) => const KatsuSettingsDialog(),
               ),

--- a/lib/pages/top_page.dart
+++ b/lib/pages/top_page.dart
@@ -3,6 +3,7 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:xen2/components/gradient_slider.dart';
 import 'package:xen2/components/primary_button.dart';
 import 'package:xen2/constants/app_colors.dart';
+import 'package:xen2/features/katsu_settings/katsu_settings_dialog.dart';
 import 'package:xen2/features/zazen/zazen_duration_provider.dart';
 import 'package:xen2/pages/play_page.dart';
 
@@ -15,40 +16,58 @@ class TopPage extends ConsumerWidget {
 
     return Scaffold(
       backgroundColor: AppColors.background,
-      body: SafeArea(
-        child: Center(
-          child: Padding(
-            padding: const EdgeInsets.symmetric(vertical: 40),
-            child: Column(
-              mainAxisAlignment: MainAxisAlignment.spaceBetween,
-              children: [
-                // GradientSliderが中央に来るようにするためのスペーサー
-                SizedBox(),
-                SizedBox(
-                  width: 400,
-                  child: GradientSlider(
-                    value: duration,
-                    onChanged: (minutes) {
-                      ref.read(zazenDurationProvider.notifier).update(minutes);
-                    },
-                  ),
+      body: Stack(
+        children: [
+          SafeArea(
+            child: Center(
+              child: Padding(
+                padding: const EdgeInsets.symmetric(vertical: 40),
+                child: Column(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  children: [
+                    // GradientSliderが中央に来るようにするためのスペーサー
+                    SizedBox(),
+                    SizedBox(
+                      width: 400,
+                      child: GradientSlider(
+                        value: duration,
+                        onChanged: (minutes) {
+                          ref
+                              .read(zazenDurationProvider.notifier)
+                              .update(minutes);
+                        },
+                      ),
+                    ),
+                    SizedBox(
+                      width: 400,
+                      child: PrimaryButton(
+                        label: '禅',
+                        onPressed: () {
+                          Navigator.pushReplacement(
+                            context,
+                            MaterialPageRoute(builder: (_) => const PlayPage()),
+                          );
+                        },
+                      ),
+                    ),
+                  ],
                 ),
-                SizedBox(
-                  width: 400,
-                  child: PrimaryButton(
-                    label: '禅',
-                    onPressed: () {
-                      Navigator.pushReplacement(
-                        context,
-                        MaterialPageRoute(builder: (_) => const PlayPage()),
-                      );
-                    },
-                  ),
-                ),
-              ],
+              ),
             ),
           ),
-        ),
+          Positioned(
+            top: 0,
+            right: 0,
+            child: GestureDetector(
+              behavior: HitTestBehavior.opaque,
+              onTap: () => showDialog(
+                context: context,
+                builder: (_) => const KatsuSettingsDialog(),
+              ),
+              child: const SizedBox(width: 40, height: 40),
+            ),
+          ),
+        ],
       ),
     );
   }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -281,6 +281,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.1.3"
+  device_info_plus:
+    dependency: transitive
+    description:
+      name: device_info_plus
+      sha256: "6a642e1daa10190af89ba6cb6386c0df7d071a3592080bfe1e44faa63ae1df65"
+      url: "https://pub.dev"
+    source: hosted
+    version: "13.1.0"
+  device_info_plus_platform_interface:
+    dependency: transitive
+    description:
+      name: device_info_plus_platform_interface
+      sha256: "04b173a92e2d9161dfead145667037c8d834db725ce2e7b942bfe18fd2f45a46"
+      url: "https://pub.dev"
+    source: hosted
+    version: "8.1.0"
   fake_async:
     dependency: transitive
     description:
@@ -297,6 +313,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.2.0"
+  ffi_leak_tracker:
+    dependency: transitive
+    description:
+      name: ffi_leak_tracker
+      sha256: "4093d4ef9ca06ffe2786e73bfb25e22aa92112b9bb4ec941f11e3e6b61489a97"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.2"
   file:
     dependency: transitive
     description:
@@ -1005,6 +1029,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.2.0"
+  vibration:
+    dependency: "direct main"
+    description:
+      name: vibration
+      sha256: c6c25eb7acadfd231925a60004736443cbf63f1eb5740d6dd83a1bc09cf00f6d
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.0"
+  vibration_platform_interface:
+    dependency: transitive
+    description:
+      name: vibration_platform_interface
+      sha256: "258c273268f8aa40c88d29741137c536874a738779b92ddb8aa32ed093721ec5"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.2"
   vm_service:
     dependency: transitive
     description:
@@ -1061,6 +1101,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.2.1"
+  win32:
+    dependency: transitive
+    description:
+      name: win32
+      sha256: ba6f4bba816c8d7e3c1580e170f3786d216951cc6b94babc3b814c08d2cb2738
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.3.0"
+  win32_registry:
+    dependency: transitive
+    description:
+      name: win32_registry
+      sha256: "73b1d78920a9d6e03f8b4e43e612b87bf3152a0e5c5e5150267762b7c4116904"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.3"
   xdg_directories:
     dependency: transitive
     description:
@@ -1087,4 +1143,4 @@ packages:
     version: "3.1.3"
 sdks:
   dart: ">=3.11.4 <4.0.0"
-  flutter: ">=3.38.4"
+  flutter: ">=3.41.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -45,6 +45,7 @@ dependencies:
   audioplayers: ^6.6.0
   flutter_dotenv: ^6.0.0
   http: ^1.6.0
+  vibration: ^3.0.0
   perfect_freehand: ^2.5.2+1
   flutter_svg: ^2.3.0
 


### PR DESCRIPTION
close #44 

- KatsuSettings プロバイダー（keepAlive）を新規追加
- 設定ダイアログを新規追加（Pavlok ON/OFF・刺激値スライダー・バイブ ON/OFF）
- トップ右上に透明ボタンを追加（ロングプレスでダイアログ表示）
- 喝発生時に設定値で Pavlok / バイブ / 何もしない を分岐
- Pavlok OFF 時はウェアラブルデバイス装着ステップをスキップ
- vibration パッケージを追加